### PR TITLE
Revert dependency version of pyqt5 from 5.10.1 to 5.9.2

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -95,8 +95,9 @@
                 "sha256:4db7113f464c733a99fcb66c4c093a47cf7204ad3f8b3bda502efcc0839ac14b",
                 "sha256:9c17ab3974c1fc7bbb04cc1c9dae780522c0ebc158613f3025fccae82227b5f7",
                 "sha256:f6035baa009acf45e5f460cf88f73580ad5dc0e72330029acd99e477f20a5d61"
+                "sha256:5dab7244b6932606490b47a0692e03d7b72d89f7d3dfa3d147a8b34d6af72451"
             ],
-            "version": "==5.10.1"
+            "version": "==5.9.2"
         },
         "pywin32": {
             "hashes": [


### PR DESCRIPTION
fixes #187

Problem: ``ninja run`` fails as follows

INFO:MainThread:launcher.main: Running Knossos 0.14.0-dev+70463d8 on PyQt5 and Python 3.7.5 (default, Nov 20 2019, 09:21:52)
[GCC 9.2.1 20191008].
INFO:MainThread:launcher.main: OpenSSL version: OpenSSL 1.1.1c  28 May 2019
[0324/090712.036699:WARNING:stack_trace_posix.cc(648)] Failed to open file: /tmp/.gluQvmCt (deleted)
  Error: No such file or directory
Could not find QtWebEngineProcess
[6762:6762:0324/090712.203018:FATAL:zygote_host_impl_linux.cc(182)] Check failed: ReceiveFixedMessage(fds[0], kZygoteBootMessage, sizeof(kZygoteBootMessage), &boot_pid). 

workaround documented here: https://github.com/qutebrowser/qutebrowser/issues/3662

